### PR TITLE
Add a button to upload the demo schedule instead of a local file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "launch": "pip install -r requirements.txt && python app.py"
+  }
+}

--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ def generate_schedule(file_path):
 @app.route('/', methods=['GET', 'POST'])
 def upload_file():
     if request.method == 'POST':
-        file = request.files['file']
+        file = request.files.get('file')
         if file:
             if file.filename.endswith('.csv'):
                 # Save the uploaded file to a temporary directory
@@ -100,6 +100,17 @@ def upload_file():
             return jsonify({'error': 'No file selected for upload.'}), 400
 
     return render_template('upload.html')
+
+@app.route('/upload_demo_schedule', methods=['POST'])
+def upload_demo_schedule():
+    demo_file_path = 'daily_schedule.csv'
+    try:
+        schedule = generate_schedule(demo_file_path)
+        session['schedule'] = schedule  # Store the schedule in the session
+        return jsonify({'redirect': '/schedule'})
+    except Exception as e:
+        error_message = str(e)
+        return jsonify({'error': error_message}), 500
 
 @app.route('/schedule')
 def show_schedule():

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -15,6 +15,7 @@
                     <input type="submit" value="Upload" class="btn btn-primary">
                 </div>
             </form>
+            <button id="upload-demo-schedule" class="btn btn-secondary">Upload Demo Schedule</button>
             <div id="error-message" class="error-message"></div>
         </div>
     </div>
@@ -31,6 +32,24 @@
                     data: formData,
                     processData: false,
                     contentType: false,
+                    success: function(response) {
+                        if (response.redirect) {
+                            window.location.href = response.redirect;
+                        } else {
+                            $('#error-message').text('Unexpected response from the server.');
+                        }
+                    },
+                    error: function(xhr) {
+                        var errorMessage = xhr.responseJSON.error;
+                        $('#error-message').text(errorMessage);
+                    }
+                });
+            });
+
+            $('#upload-demo-schedule').click(function() {
+                $.ajax({
+                    url: '/upload_demo_schedule',
+                    type: 'POST',
                     success: function(response) {
                         if (response.redirect) {
                             window.location.href = response.redirect;
@@ -96,6 +115,16 @@
             border: none;
             border-radius: 5px;
             cursor: pointer;
+        }
+
+        .btn-secondary {
+            padding: 10px 20px;
+            background-color: #6c757d;
+            color: #fff;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            margin-top: 10px;
         }
 
         .error-message {


### PR DESCRIPTION
Related to #3

Add a button to upload the demo schedule instead of a local file.

* **app.py**
  - Add a new route `/upload_demo_schedule` to handle the demo schedule upload.
  - Modify the `upload_file` function to use `request.files.get('file')` instead of `request.files['file']`.
  - Add a new function `upload_demo_schedule` to process the demo schedule from `daily_schedule.csv`.

* **templates/upload.html**
  - Add a button with id `upload-demo-schedule` to upload the demo schedule.
  - Modify the AJAX script to handle the demo schedule upload when the new button is clicked.
  - Add CSS styling for the new button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KyanBasil/freshbotv2/issues/3?shareId=0ad078f1-b6d3-4b7b-acee-e94e61978a50).